### PR TITLE
Corrige identificador de comentário

### DIFF
--- a/editor.ts
+++ b/editor.ts
@@ -532,14 +532,34 @@ const configurarAtualizacaoAutomatica = function () {
 
 const configurarLinguagemPitugues = function () {
     const primitivas = (globalThis as any).primitivas;
-    Monaco.languages?.register({
-        id: 'pitugues',
-        extensions: ['.pitugues'],
-        aliases: ['pitugues', 'language-generation'],
-        mimetypes: ['application/pitugues'],
+    Monaco.languages.register({ id: 'pitugues' });
+
+    Monaco.languages.setLanguageConfiguration('pitugues', {
+        comments: {
+            lineComment: '#'
+        },
+        brackets: [
+            ['{', '}'],
+            ['[', ']'],
+            ['(', ')']
+        ],
+        autoClosingPairs: [
+            { open: '{', close: '}' },
+            { open: '[', close: ']' },
+            { open: '(', close: ')' },
+            { open: '"', close: '"' },
+            { open: "'", close: "'" }
+        ]
     });
 
-    Monaco.languages.setMonarchTokensProvider('pitugues', definirLinguagemPitugues());
+    Monaco.languages.setMonarchTokensProvider('pitugues', {
+        tokenizer: {
+            root: [
+                [/#.*$/, 'comment']  // reconhece comentários iniciados com #
+            ]
+        }
+    });
+
 
     Monaco.languages.registerCompletionItemProvider('pitugues', {
         provideCompletionItems: () => {


### PR DESCRIPTION
Altera identificador de comentário padrão para '#' assim como no Python.
## Anexos 
<img width="1788" height="907" alt="image" src="https://github.com/user-attachments/assets/c54b16d6-0b91-47bd-81a9-791ae67247a1" />
fix #7 