### PR TITLE
Adiciona realces a sintaxe

### DIFF
--- a/editor.ts
+++ b/editor.ts
@@ -415,19 +415,14 @@ function definirLinguagemPitugues() {
         [/'/, 'string', '@string_single'],
         [/`/, 'string', '@string_backtick']
       ],
+        whitespace: [
+        [/[ \t\r\n]+/, ''],         // espaços, tabs e quebras de linha
+        [/#.*$/, 'comment']         // reconhece comentários iniciados com #
+        ],
 
-      whitespace: [
-        [/[ \t\r\n]+/, ''],
-        [/\/\*\*(?!\/)/, 'comment.doc', '@jsdoc'],
-        [/\/\*/, 'comment', '@comment'],
-        [/\/\/.*$/, 'comment']
-      ],
-
-      comment: [
-        [/[^\/*]+/, 'comment'],
-        [/\*\//, 'comment', '@pop'],
-        [/[\/*]/, 'comment']
-      ],
+        comment: [
+        [/#.*$/, 'comment']         // mantém compatível caso o estado seja usado
+        ],
 
       jsdoc: [
         [/[^\/*]+/, 'comment.doc'],
@@ -532,33 +527,15 @@ const configurarAtualizacaoAutomatica = function () {
 
 const configurarLinguagemPitugues = function () {
     const primitivas = (globalThis as any).primitivas;
-    Monaco.languages.register({ id: 'pitugues' });
-
-    Monaco.languages.setLanguageConfiguration('pitugues', {
-        comments: {
-            lineComment: '#'
-        },
-        brackets: [
-            ['{', '}'],
-            ['[', ']'],
-            ['(', ')']
-        ],
-        autoClosingPairs: [
-            { open: '{', close: '}' },
-            { open: '[', close: ']' },
-            { open: '(', close: ')' },
-            { open: '"', close: '"' },
-            { open: "'", close: "'" }
-        ]
+    Monaco.languages.register({ id: 'pitugues',
+        extensions: ['.pitu'],
+        aliases: ['Pituguês', 'language-generation'],
+        mimetypes: ['application/pitugues'] 
     });
 
-    Monaco.languages.setMonarchTokensProvider('pitugues', {
-        tokenizer: {
-            root: [
-                [/#.*$/, 'comment']  // reconhece comentários iniciados com #
-            ]
-        }
-    });
+
+
+    Monaco.languages.setMonarchTokensProvider('pitugues', definirLinguagemPitugues());
 
 
     Monaco.languages.registerCompletionItemProvider('pitugues', {


### PR DESCRIPTION
Este PR corrige a configuração da linguagem no editor. Garantindo que todos os padrões sejam aplicados corretamente, especialmente os destaques de sintaxe.

## Arquivo Modificado
- `editor.ts` - Ajuste na configuração da linguagem para garantir a aplicação correta dos padrões de sintaxe.

## Anexos 
<img width="1788" height="907" alt="image" src="https://github.com/user-attachments/assets/138baf68-b2e0-412c-8aab-e0727ccf956a" />


## Issue Relacionada
Closes #9
