### PR TITLE
Adiciona suporte para importação de bibliotecas 

### DIFF
--- a/interpretador-web.ts
+++ b/interpretador-web.ts
@@ -1,40 +1,51 @@
-import { Importar, Interpretador, Literal, SimboloInterface } from "@designliquido/delegua";
+import { Importar, ImportarComoConstruto, Interpretador, Literal, SimboloInterface } from "@designliquido/delegua";
 import { DeleguaModulo } from "@designliquido/delegua/interpretador/estruturas";
 import { ErroEmTempoDeExecucao } from "@designliquido/delegua/excecoes";
+
 export class InterpretadorWeb 
     extends Interpretador
 {
-   constructor(
+    constructor(
         diretorioBase: string,
         performance = false,
         funcaoDeRetorno: Function = null,
-        funcaoDeRetornoMesmaLinha: Function = null 
+        funcaoDeRetornoMesmaLinha: Function = null
     ) {
         super(diretorioBase, performance, funcaoDeRetorno, funcaoDeRetornoMesmaLinha);
     }
 
-    override async visitarDeclaracaoImportar(declaracao: Importar): Promise<DeleguaModulo> {
-        // TODO: Resolver isso não considerando que é um Literal.
-        const caminhoResolvido = declaracao.caminho as Literal;
-        switch (caminhoResolvido.valor) {
+    protected async logicaComumImportar(caminho: Literal, linha: number): Promise<DeleguaModulo> {
+        switch (caminho.valor) {
             case 'criptografia':
             case 'estatistica':
             case 'fisica':
             case 'json':
             case 'matematica':
             case 'tempo':
-                const variavelDoModulo = this.pilhaEscoposExecucao.obterVariavelPorNome(caminhoResolvido.valor);
+                const variavelDoModulo = this.pilhaEscoposExecucao.obterVariavelPorNome(caminho.valor);
                 const moduloResolvido = variavelDoModulo.valor as DeleguaModulo;
                 return Promise.resolve(moduloResolvido);
             default:
                 throw new ErroEmTempoDeExecucao(
                     {
                         hashArquivo: -1,
-                        linha: declaracao.linha,
+                        linha: linha,
                     } as SimboloInterface,
-                    `Biblioteca ${caminhoResolvido.valor} não está disponível neste módulo Web. Para suporte a mais bibliotecas, por favor verifique a solução completa, em https://github.com/DesignLiquido/delegua-completo.`,
-                    declaracao.linha
+                    `Biblioteca ${caminho.valor} não está disponível neste módulo Web. Para suporte a mais bibliotecas, por favor verifique a solução completa, em https://github.com/DesignLiquido/delegua-completo.`,
+                    linha
                 );
         }
+    }
+
+    override async visitarDeclaracaoImportar(declaracao: Importar): Promise<DeleguaModulo> {
+        // TODO: Resolver isso não considerando que é um Literal.
+        const caminhoResolvido = declaracao.caminho as Literal;
+        return this.logicaComumImportar(caminhoResolvido, declaracao.linha);
+    }
+
+    override async visitarExpressaoImportar(expressao: ImportarComoConstruto): Promise<DeleguaModulo> {
+        // TODO: Resolver isso não considerando que é um Literal.
+        const caminhoResolvido = expressao.caminho as Literal;
+        return this.logicaComumImportar(caminhoResolvido, expressao.linha);
     }
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@chakra-ui/react": "^2.10.9",
-    "@designliquido/delegua": "^0.63.0",
-    "@designliquido/delegua-criptografia": "^0.0.4",
+    "@designliquido/delegua": "^0.64.0",
+    "@designliquido/delegua-criptografia": "^0.3.3",
     "@designliquido/delegua-estatistica": "^0.1.0",
     "@designliquido/delegua-fisica": "^0.1.0",
     "@designliquido/delegua-json": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,10 +152,10 @@
     "@types/lodash.mergewith" "4.6.9"
     lodash.mergewith "4.6.2"
 
-"@designliquido/delegua-criptografia@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@designliquido/delegua-criptografia/-/delegua-criptografia-0.0.4.tgz#ee937c586aa5094b0c2d8794228c5719943a9b02"
-  integrity sha512-CWOIo3jhBCCCQ/SfUH79N/u05oMq14FvmSZdefVL3vnK19+xSLKWHf2JxH7r9bFt1P4I3I9jSTM3nvqOsDlcxQ==
+"@designliquido/delegua-criptografia@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@designliquido/delegua-criptografia/-/delegua-criptografia-0.3.3.tgz#42d39ee27b4c7abb05656829ef6526655464a117"
+  integrity sha512-eIOZT+/MRJFDWru/yJHmxXyjNfMQ2tff6ioapb5YR/LmYdoa5ELtueVhFzpXEgPLksCLLjrntNPFFhXe5g2KXQ==
 
 "@designliquido/delegua-estatistica@^0.1.0":
   version "0.1.0"
@@ -186,10 +186,10 @@
   dependencies:
     dayjs "^1.11.13"
 
-"@designliquido/delegua@^0.63.0":
-  version "0.63.0"
-  resolved "https://registry.yarnpkg.com/@designliquido/delegua/-/delegua-0.63.0.tgz#9c3a4cf79832cdafbcbdc27715f8ecf37947c29d"
-  integrity sha512-oYD45CKCL8tvGB4oLYJ0R6JgQ9BbJ3X2p2fdjBbzypGN6AfNIxRTdW2gDaS/DYj0gEuFdKipQrSFSB5StNDnow==
+"@designliquido/delegua@^0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@designliquido/delegua/-/delegua-0.64.0.tgz#62e951d3ac32c81b7edac82b90c33a181bdb9ba8"
+  integrity sha512-I45tOIaeTSJCfIywdB+weicXQNI0DUgsc7l7XWhninCdpETzqQHPNS3i3Gr5mlZaQhiwPSG+ffrsU+/+yAPCZw==
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
     browser-process-hrtime "^1.0.0"


### PR DESCRIPTION
Atualiza as dependências do projeto para as versões 0.64.0 do núcleo de Delégua e 0.3.3 da biblioteca de criptografia; refatora a lógica de importação no interpretador web.